### PR TITLE
chore: add tailwindcss v4 to peerDependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "tailwindcss": "^3.4.17"
+        "tailwindcss": "^3.4.17 || ^4.0.0"
       }
     },
     "node_modules/@alloc/quick-lru": {

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "vite": "^6.2.0"
   },
   "peerDependencies": {
-    "tailwindcss": "^3.4.17"
+    "tailwindcss": "^3.4.17 || ^4.0.0"
   },
   "engines": {
     "node": ">=18"


### PR DESCRIPTION
現状 peerDependencies を Tailwind v3系に縛っていて、v4 を使うには `--legacy-peer-deps` オプションでインストールする必要がありますが、Tailwind CSS v4 でも [@pluginディレクティブ](https://tailwindcss.com/docs/functions-and-directives#plugin-directive) で tailwind-theme-plugin を使うことは可能であるのが確認できましたので、 peerDependencies に `^v4.0.0` も追加しました。