### PR TITLE
chore: update dependabot configuration to specify package directories

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,10 @@
 version: 2
 updates:
   - package-ecosystem: "npm"
-    directory: "/" # Location of package manifests
+    directory: "/builder/" # Location of package manifests
+    schedule:
+      interval: "daily"
+  - package-ecosystem: "npm"
+    directory: "/examples/" # Location of package manifests
     schedule:
       interval: "daily"


### PR DESCRIPTION
https://github.com/digital-go-jp/design-tokens/pull/200 と同様に、前回のリリースでディレクトリ構造を変更してから、Dependabot が動作していなかったので、dependabot.yml のディレクトリの指定を修正。

また、`/examples/` にも package.json があるので、そちらも追加。