### PR TITLE
chore: update publish workflow for npm trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v5
         with:
-          node-version: "22.22.0"
+          node-version: "^22.22.0"
           registry-url: "https://registry.npmjs.org"
       - name: Install latest npm
         run: npm install -g npm@latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,6 @@
 name: Publish package to npmjs
 permissions:
+  id-token: write
   contents: read
 on:
   release:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -9,14 +9,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
-          node-version: 22
+          node-version: "22.22.0"
           registry-url: "https://registry.npmjs.org"
+      - name: Install latest npm
+        run: npm install -g npm@latest
       - run: npm ci
         working-directory: ./builder
       - run: npm run build
         working-directory: ./builder
-      - run: npm publish --access=public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - run: npm publish --provenance --access public


### PR DESCRIPTION
- classic token から npm trusted publishing に npm パッケージの公開方法を切り替えのため、workflow を修正
- Node.js バージョンを "22.22.0" に固定